### PR TITLE
Fixing compile errors and structural faults

### DIFF
--- a/bachproef/Resultaten_enquête.tex
+++ b/bachproef/Resultaten_enquête.tex
@@ -258,7 +258,7 @@ Dit werd ingevuld door de personen die niet gekend zijn met Cisco Identity Servi
 	\end{center}
 \end{table}
 
-\textbf{Vraag 15: Is volgens u een network access control product noodzakelijk in een bedrijfsomgeving?
+\textbf{Vraag 15: Is volgens u een network access control product noodzakelijk in een bedrijfsomgeving?}
 
 \begin{table}[h!]
 	\begin{center}

--- a/bachproef/analyse_bachelor_thesis.py
+++ b/bachproef/analyse_bachelor_thesis.py
@@ -27,7 +27,7 @@ def print_result(analysis_result: Dict[str, Any]) -> None:
     to_print = "### Metrics\n```\n" + tabulate.tabulate(data, tablefmt="github") + '\n```'
     # use newline char for url encoding instead of standard one
     # to get multiline output shown in release body
-    to_print = to_print.replace('\n', '%0A')
+    # to_print = to_print.replace('\n', '%0A')
     print(to_print)
 
 def analyse_pdf(file_name: str) -> Dict[str, Any]:
@@ -71,8 +71,7 @@ def get_occurence_amounts(node: Any, document_tree: Any) -> int:
     
 def get_document_tree(file_name: str) -> Any:
     # merge all tex's into one
-    os.system("chmod +x recursivelyMergeTex.awk")
-    os.system(f"./recursivelyMergeTex.awk < {file_name} > combined_temp.tex")
+    os.system(f"./recursivelyMergeTex.awk < {file_name} > combined_temp.tex 2>/dev/null")
     
     with open('combined_temp.tex') as f: data = f.read()
     tree = TexSoup.TexSoup(data)
@@ -103,7 +102,6 @@ def remove_unnecessary_nodes(document_tree: Any) -> None:
         'figure',
         'lstlisting',
         'verbatim',
-        'table',
         'printbibliography'
     ]
     for node in nodes_to_remove:
@@ -164,15 +162,3 @@ def get_word_count(text: str) -> int:
 
 if __name__== "__main__":
     main()
-© 2020 GitHub, Inc.
-Terms
-Privacy
-Security
-Status
-Help
-Contact GitHub
-Pricing
-API
-Training
-Blog
-About

--- a/bachproef/bachproef-tin.tex
+++ b/bachproef/bachproef-tin.tex
@@ -42,7 +42,7 @@
 \inserttitlepage
 
 %---------- Samenvatting, voorwoord --------------------------------------------
-%\usechapterimagefalse
+\usechapterimagefalse
 \input{voorwoord}
 \input{samenvatting}
 
@@ -83,7 +83,7 @@ Het onderwerp van deze bachelorproef is gebaseerd op een onderzoeksvoorstel dat 
 
 %%---------- Andere bijlagen --------------------------------------------------
 % TODO: Voeg hier eventuele andere bijlagen toe
-\input{Resultaten enquête}
+\input{Resultaten_enquête}
 
 %%---------- Referentielijst --------------------------------------------------
 

--- a/bachproef/proofofconcept.tex
+++ b/bachproef/proofofconcept.tex
@@ -215,6 +215,7 @@ In onderstaande lijst vindt u de specificaties van de Cisco Catalyst 2960-CX ser
 	\item Besturingsysteem/software:
 	\begin{itemize}
 		\item OS: Cisco IOS
+    \end{itemize}
 \end{itemize}
 
 \begin{figure}[H]

--- a/bachproef/resultaten.tex
+++ b/bachproef/resultaten.tex
@@ -1,5 +1,5 @@
 
- \chapter{\IfLanguageName{dutch}{resultaten}{resultaten}}
+ \chapter{\IfLanguageName{dutch}{Resultaten}{Resultaten}}
 \label{ch:Resultaten}
 In dit hoofdstuk zullen de resultaten van de testen en de enquête verwerkt worden om zo tot een antwoord te komen op dit onderzoek. Hierbij zijn de resultaten van de Cisco Identity Services Engine omgeving opgedeeld in 'Port-based en Policy-based network access control' en 'Tread-Centric en Policy-based network access control'. Vervolgens zijn de enquête resultaten verwerkt met een aantal diagrammen. Deze resultaten zijn ingedeelt per vraag. 
 


### PR DESCRIPTION
**Fout 1:**
Op lijn 45 van bachproef-tin.tex staat "\usechapterimagefalse" in commentaar, dit moet uit commentaar en fixt alle compile errors op één na

**Fout 2:**
Op lijn 216 van proofofconcept.text staat "\begin{itemize}", maar je sluit hem nooit af dus na lijn 217 moet "\end{itemize}". Dit fixt de laatste compile error

**Fout 3:**
Geen compile error maar wel structurele fout: je krijgt twee keer uw resultaten in uw bp in plaats van 1x uw resultaat en 1x uw enquete resultaat. Komt doordat je een spatie hebt gebruikt in uw file naam, hernoem "Resultaten enquête.tex" naar "Resultaten_enquête.tex" en pas uw input tag op lijn 90 van bachproef-tin.tex aan met dezelfde underscore

**Fout 4:**
Nu krijgen we weer één compile error omdat uw enquete resultaten nu wel opgenomen zijn in uw BP maar daarin zit dus ook nog een fout: op lijn 261 van Resultaten enquête.tex vergat je uw accolade te sluiten, er moet dus een } bij